### PR TITLE
SIDM-5009 extract idm session cookie

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ project.ext {
     junit_version = "4.12"
 }
 
-version = '2.5.0'
+version = '2.5.1'
 group = 'uk.gov.hmcts.reform.idam'
 
 description = """idam-forgerock-http-client"""
@@ -70,6 +70,8 @@ dependencies {
     implementation "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:$oltu_version"
     implementation "com.brsanthu:migbase64:2.2"
     testImplementation "junit:junit:$junit_version"
+    testImplementation 'org.mockito:mockito-core:3.12.4'
+    testImplementation 'org.mockito:mockito-inline:3.12.4'
 }
 
 def generateCodeFromSwagger(swaggerSourceFile, packageName, importMappings) {

--- a/src/test/java/uk/gov/hmcts/reform/idam/api/fr/idm/misc/LoginApiTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/api/fr/idm/misc/LoginApiTest.java
@@ -1,0 +1,111 @@
+package uk.gov.hmcts.reform.idam.api.fr.idm.misc;
+
+import feign.Response;
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoginApiTest {
+
+    @Mock
+    LoginApi underTest;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    Response response;
+
+    @Before
+    public void setup() {
+        given(underTest.getSessionJWT(any(), any())).willCallRealMethod();
+        given(underTest.idmLogin(any(), any())).willReturn(response);
+    }
+
+    @Test
+    public void testGetSessionJWT_oneSessionCookie() {
+        given(response.status()).willReturn(HttpStatus.SC_OK);
+        given(response.headers().get(HttpHeaders.SET_COOKIE)).willReturn(Collections.singletonList("session-jwt=cookie1"));
+
+        assertThat(underTest.getSessionJWT("test-user", "test-pass"), is("session-jwt=cookie1"));
+    }
+
+    @Test
+    public void testGetSessionJWT_twoCookiesWithOneSession() {
+        given(response.status()).willReturn(HttpStatus.SC_OK);
+        given(response.headers().get(HttpHeaders.SET_COOKIE)).willReturn(Arrays.asList("cookie1", "session-jwt=cookie2"));
+
+        assertThat(underTest.getSessionJWT("test-user", "test-pass"), is("session-jwt=cookie2"));
+    }
+
+    @Test
+    public void testGetSessionJWT_twoCookiesWithTwoSessions() {
+        given(response.status()).willReturn(HttpStatus.SC_OK);
+        given(response.headers().get(HttpHeaders.SET_COOKIE)).willReturn(Arrays.asList("session-jwt=cookie1", "session-jwt=cookie2"));
+
+        assertThat(underTest.getSessionJWT("test-user", "test-pass"), is("session-jwt=cookie1"));
+    }
+
+    @Test
+    public void testGetSessionJWT_twoCookiesWithoutSession() {
+        given(response.status()).willReturn(HttpStatus.SC_OK);
+        given(response.headers().get(HttpHeaders.SET_COOKIE)).willReturn(Arrays.asList("cookie1", "cookie2"));
+        try {
+            underTest.getSessionJWT("test-user", "test-pass");
+            fail();
+        } catch (HttpClientErrorException hcee) {
+            assertThat(hcee.getRawStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+            assertThat(hcee.getMessage(), is("invalid username or password"));
+        }
+    }
+
+    @Test
+    public void testGetSessionJWT_test4xxErrorHandling() {
+        given(response.status()).willReturn(HttpStatus.SC_FORBIDDEN);
+        try {
+            underTest.getSessionJWT("test-user", "test-pass");
+            fail();
+        } catch (HttpClientErrorException hcee) {
+            assertThat(hcee.getRawStatusCode(), is(HttpStatus.SC_FORBIDDEN));
+        }
+    }
+
+    @Test
+    public void testGetSessionJWT_test401ErrorHandling() {
+        given(response.status()).willReturn(HttpStatus.SC_UNAUTHORIZED);
+        given(response.headers().get(HttpHeaders.SET_COOKIE)).willReturn(null);
+        try {
+            underTest.getSessionJWT("test-user", "test-pass");
+            fail();
+        } catch (HttpClientErrorException hcee) {
+            assertThat(hcee.getRawStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+            assertThat(hcee.getMessage(), is("invalid username or password"));
+        }
+    }
+
+    @Test
+    public void testGetSessionJWT_test5xxErrorHandling() {
+        given(response.status()).willReturn(HttpStatus.SC_BAD_GATEWAY);
+        try {
+            underTest.getSessionJWT("test-user", "test-pass");
+            fail();
+        } catch (HttpServerErrorException hsee) {
+            assertThat(hsee.getRawStatusCode(), is(HttpStatus.SC_BAD_GATEWAY));
+        }
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-5009

### Change description ###

Extract the idm session cookie instead of returning all cookies. This avoids returning any dynatrace cookies when monitoring is enabled.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
